### PR TITLE
Fix perms related to new logrotate version

### DIFF
--- a/files/etc/logrotate.conf
+++ b/files/etc/logrotate.conf
@@ -5,6 +5,10 @@
 # rotate log files weekly
 weekly
 
+# use the syslog group by default, since this is the owning group
+# # of /var/log/syslog.
+su root syslog
+
 # keep 4 weeks worth of backlogs
 rotate 4
 


### PR DESCRIPTION
A security update to logrotate package causes a lot of logs to not get rotated anymore.

I have copied a directive from the vanilla ubuntu package that is supposed to fix this in the general case.